### PR TITLE
slightly optimized packages.rs

### DIFF
--- a/src/packages.rs
+++ b/src/packages.rs
@@ -3,7 +3,7 @@
 
 use std::process::{Command, Stdio}; // For executing shell commands.
 
-pub fn get_num_packages() -> u32 {
+pub fn get_num_packages() -> i16 {
     let num_packages = packages_generic("pacman", &["-Q"])
         .or_else(|_| packages_generic("yum", &["list", "installed"]))
         .or_else(|_| packages_generic("dpkg-query", &["-l"]))
@@ -17,7 +17,7 @@ pub fn get_num_packages() -> u32 {
         .unwrap_or_else(|_| "Unknown".to_string());
 
     // Count the total number of packages
-    num_packages.lines().count() as u32
+    num_packages.lines().count() as i16
 }
 
 pub fn packages_generic(cmd: &str, options: &[&str]) -> Result<String, String> {

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -17,12 +17,7 @@ pub fn get_num_packages() -> u32 {
         .unwrap_or_else(|_| "Unknown".to_string());
 
     // Count the total number of packages
-    let mut total_count: u32 = 0;
-    for _ in num_packages.lines() {
-        total_count += 1;
-    }
-
-    total_count
+    num_packages.lines().count() as u32
 }
 
 pub fn packages_generic(cmd: &str, options: &[&str]) -> Result<String, String> {


### PR DESCRIPTION
change `u32` to `i16`, optimized the counting algorithm (for speed/conciseness) at the expense of higher memory usage

# tl;dr: you pushed a minor oversight lmao L + skill issue + bozo + cope + ratio + counter ratio + checkmate + etc this isn't twitter/x/whatevertheyrecallingitnow

`u` is basically a float number, it would be **EXTREMELY SLIM** that you would have half a package (eg 873.5). we get packages by counting the lines printed by something like `pacman -Q`, and it should be impossible to print half a line

changed integer limits from 32 bit to 16 bit. its unlikely anyone would have more than 2^15-1 packages installed. are there even that many packages in the AUR + repositories?

changed the counting algorithm from a 3-liner to an one liner:

```rust
num_packages.lines().count() as i16
```

probably faster since it isn't in a loop counting every individual line?

> EDIT: this program may use more memory (more apparent when you have a TON of packages) when counting because it loads everything into memory and then counts it instead of incrementing a value over every line found. just found that out.